### PR TITLE
Enable to trigger workflows manually

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -6,6 +6,7 @@ name: Docker
     branches:
       - main
   pull_request:
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/json.yml
+++ b/.github/workflows/json.yml
@@ -6,6 +6,7 @@ name: JSON
     branches:
       - main
   pull_request:
+  workflow_dispatch:
 
 jobs:
   detect-changes:

--- a/.github/workflows/markdown.yml
+++ b/.github/workflows/markdown.yml
@@ -6,6 +6,7 @@ name: Markdown
     branches:
       - main
   pull_request:
+  workflow_dispatch:
 
 jobs:
   detect-changes:

--- a/.github/workflows/yaml.yml
+++ b/.github/workflows/yaml.yml
@@ -6,6 +6,7 @@ name: YAML
     branches:
       - main
   pull_request:
+  workflow_dispatch:
 
 jobs:
   detect-changes:

--- a/json/workflow.yml
+++ b/json/workflow.yml
@@ -6,6 +6,7 @@ name: JSON
     branches:
       - main
   pull_request:
+  workflow_dispatch:
 
 jobs:
   detect-changes:

--- a/markdown/workflow.yml
+++ b/markdown/workflow.yml
@@ -6,6 +6,7 @@ name: Markdown
     branches:
       - main
   pull_request:
+  workflow_dispatch:
 
 jobs:
   detect-changes:

--- a/rust/workflow.yml
+++ b/rust/workflow.yml
@@ -6,6 +6,7 @@ name: Rust
     branches:
       - main
   pull_request:
+  workflow_dispatch:
 
 env:
   CARGO_INCREMENTAL: 0

--- a/terraform/workflow.yml
+++ b/terraform/workflow.yml
@@ -6,6 +6,7 @@ name: Terraform
     branches:
       - main
   pull_request:
+  workflow_dispatch:
 
 jobs:
   detect-changes:

--- a/yaml/workflow.yml
+++ b/yaml/workflow.yml
@@ -6,6 +6,7 @@ name: YAML
     branches:
       - main
   pull_request:
+  workflow_dispatch:
 
 jobs:
   detect-changes:


### PR DESCRIPTION
GitHub provides a way to trigger workflows manually through the `workflow_dispatch` event. All workflow templates have been updated to support this trigger, as have the existing workflows in this repository.