### PR TITLE
Fix printing changed files

### DIFF
--- a/.github/workflows/json.yml
+++ b/.github/workflows/json.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Print changed files
         run: |
-          for file in ${{ steps.changed-files-specific.outputs.all_changed_files }}; do
+          for file in ${{ steps.detect-changes.outputs.all_changed_files }}; do
             echo "$file"
           done
 

--- a/.github/workflows/markdown.yml
+++ b/.github/workflows/markdown.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Print changed files
         run: |
-          for file in ${{ steps.changed-files-specific.outputs.all_changed_files }}; do
+          for file in ${{ steps.detect-changes.outputs.all_changed_files }}; do
             echo "$file"
           done
 

--- a/.github/workflows/yaml.yml
+++ b/.github/workflows/yaml.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Print changed files
         run: |
-          for file in ${{ steps.changed-files-specific.outputs.all_changed_files }}; do
+          for file in ${{ steps.detect-changes.outputs.all_changed_files }}; do
             echo "$file"
           done
 

--- a/json/workflow.yml
+++ b/json/workflow.yml
@@ -29,6 +29,6 @@ jobs:
 
       - name: Print changed files
         run: |
-          for file in ${{ steps.changed-files-specific.outputs.all_changed_files }}; do
+          for file in ${{ steps.detect-changes.outputs.all_changed_files }}; do
             echo "$file"
           done

--- a/markdown/workflow.yml
+++ b/markdown/workflow.yml
@@ -29,6 +29,6 @@ jobs:
 
       - name: Print changed files
         run: |
-          for file in ${{ steps.changed-files-specific.outputs.all_changed_files }}; do
+          for file in ${{ steps.detect-changes.outputs.all_changed_files }}; do
             echo "$file"
           done

--- a/rust/workflow.yml
+++ b/rust/workflow.yml
@@ -34,6 +34,6 @@ jobs:
 
       - name: Print changed files
         run: |
-          for file in ${{ steps.changed-files-specific.outputs.all_changed_files }}; do
+          for file in ${{ steps.detect-changes.outputs.all_changed_files }}; do
             echo "$file"
           done

--- a/terraform/workflow.yml
+++ b/terraform/workflow.yml
@@ -29,6 +29,6 @@ jobs:
 
       - name: Print changed files
         run: |
-          for file in ${{ steps.changed-files-specific.outputs.all_changed_files }}; do
+          for file in ${{ steps.detect-changes.outputs.all_changed_files }}; do
             echo "$file"
           done

--- a/yaml/workflow.yml
+++ b/yaml/workflow.yml
@@ -30,6 +30,6 @@ jobs:
 
       - name: Print changed files
         run: |
-          for file in ${{ steps.changed-files-specific.outputs.all_changed_files }}; do
+          for file in ${{ steps.detect-changes.outputs.all_changed_files }}; do
             echo "$file"
           done


### PR DESCRIPTION
When copy & pasting the step to print changed files, we accidentally did not update the step identifier.