### PR TITLE
Switch to reusable Renovate configuration

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,12 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:base", ":disableDependencyDashboard"],
-
-  "semanticCommits": "disabled",
-
-  "pre-commit": {
-    "enabled": true
-  },
+  "extends": ["local>otterbuild/renovate-config"],
 
   "github-actions": {
     "fileMatch": ["^[\\w]+\\/[\\w]+\\.yml$"]


### PR DESCRIPTION
Renovate makes it easy to share a base configuration across projects. We are now using the default configuration for the otterbuild organization so that all repositories use the same settings.