### PR TITLE
Give jobs unique names

### DIFF
--- a/.github/flowcrafter.yml
+++ b/.github/flowcrafter.yml
@@ -1,0 +1,18 @@
+# This file is managed by FlowCrafter. Manual changes will be overwritten
+# the next time you run FlowCrafter.
+---
+library:
+  local:
+    path: .
+workflows:
+  - name: json
+    jobs:
+      - style
+  - name: markdown
+    jobs:
+      - lint
+      - style
+  - name: yaml
+    jobs:
+      - lint
+      - style

--- a/.github/workflows/json.yml
+++ b/.github/workflows/json.yml
@@ -34,7 +34,7 @@ jobs:
           done
 
   style:
-    name: Check style
+    name: Check JSON style
     runs-on: ubuntu-latest
 
     needs: detect-changes

--- a/.github/workflows/markdown.yml
+++ b/.github/workflows/markdown.yml
@@ -34,7 +34,7 @@ jobs:
           done
 
   lint:
-    name: Lint code
+    name: Lint Markdown files
     runs-on: ubuntu-latest
 
     needs: detect-changes
@@ -50,7 +50,7 @@ jobs:
           files: "**.md"
 
   style:
-    name: Check style
+    name: Check Markdown style
     runs-on: ubuntu-latest
 
     needs: detect-changes

--- a/.github/workflows/yaml.yml
+++ b/.github/workflows/yaml.yml
@@ -35,7 +35,7 @@ jobs:
           done
 
   lint:
-    name: Lint code
+    name: Lint YAML files
     runs-on: ubuntu-latest
 
     needs: detect-changes
@@ -49,7 +49,7 @@ jobs:
         uses: actionshub/yamllint@v1.8.2
 
   style:
-    name: Check style
+    name: Check YAML style
     runs-on: ubuntu-latest
 
     needs: detect-changes

--- a/json/style.yml
+++ b/json/style.yml
@@ -1,5 +1,5 @@
 style:
-  name: Check style
+  name: Check JSON style
   runs-on: ubuntu-latest
 
   needs: detect-changes

--- a/markdown/lint.yml
+++ b/markdown/lint.yml
@@ -1,5 +1,5 @@
 lint:
-  name: Lint code
+  name: Lint Markdown files
   runs-on: ubuntu-latest
 
   needs: detect-changes

--- a/markdown/style.yml
+++ b/markdown/style.yml
@@ -1,5 +1,5 @@
 style:
-  name: Check style
+  name: Check Markdown style
   runs-on: ubuntu-latest
 
   needs: detect-changes

--- a/rust/lint.yml
+++ b/rust/lint.yml
@@ -1,5 +1,5 @@
 lint:
-  name: Lint code
+  name: Lint Rust code
   runs-on: ubuntu-latest
 
   needs: detect-changes

--- a/rust/style.yml
+++ b/rust/style.yml
@@ -1,5 +1,5 @@
 style:
-  name: Check style
+  name: Check Rust style
   runs-on: ubuntu-latest
 
   needs: detect-changes

--- a/rust/test.yml
+++ b/rust/test.yml
@@ -1,5 +1,5 @@
 test:
-  name: Run tests
+  name: Run Rust tests
   runs-on: ubuntu-latest
 
   needs: detect-changes

--- a/terraform/lint.yml
+++ b/terraform/lint.yml
@@ -1,5 +1,5 @@
 lint:
-  name: Lint code
+  name: Lint Terraform files
   runs-on: ubuntu-latest
 
   needs: detect-changes

--- a/terraform/security.yml
+++ b/terraform/security.yml
@@ -1,5 +1,5 @@
 security:
-  name: Audit security
+  name: Audit Terraform files
   runs-on: ubuntu-latest
 
   needs: detect-changes

--- a/terraform/style.yml
+++ b/terraform/style.yml
@@ -1,5 +1,5 @@
 style:
-  name: Check style
+  name: Check Terraform style
   runs-on: ubuntu-latest
 
   needs: detect-changes

--- a/yaml/lint.yml
+++ b/yaml/lint.yml
@@ -1,5 +1,5 @@
 lint:
-  name: Lint code
+  name: Lint YAML files
   runs-on: ubuntu-latest
 
   needs: detect-changes

--- a/yaml/style.yml
+++ b/yaml/style.yml
@@ -1,5 +1,5 @@
 style:
-  name: Check style
+  name: Check YAML style
   runs-on: ubuntu-latest
 
   needs: detect-changes


### PR DESCRIPTION
The previous system that used the same name for the same type of job, e.g. `Lint code`, made it very easy to configure branch protection rules. Since the jobs shared the same name across file extensions, a single required status check covered all jobs.

When allowing Renovate to merge its own pull requests, we discovered an issue with this approach. When a pull request was opened, Renovate would only wait for the first required status checks to be skipped. GitHub counts skipped checks as successful, so from the perspective of Renovate all tests at that moment had succeeded. It wasn't aware of checks with the same name starting a little bit later.

This timing issue cannot be fixed with Renovate's configuration. So we are switching to unique job names that can be required individually as status checks. This enables us to force Renovate to wait until all languages have determined whether its tests must run.